### PR TITLE
removes rich-text configs

### DIFF
--- a/backend/lib/area.js
+++ b/backend/lib/area.js
@@ -1,43 +1,5 @@
 module.exports = {
   '@apostrophecms/image': {},
   '@apostrophecms/video': {},
-  '@apostrophecms/rich-text': {
-    toolbar: [
-      'styles',
-      '|',
-      'bold',
-      'italic',
-      'strike',
-      'link',
-      '|',
-      'bulletList',
-      'orderedList',
-      '|',
-      'blockquote',
-      'codeBlock',
-      '|',
-      'horizontalRule',
-      '|',
-      'undo',
-      'redo'
-    ],
-    styles: [
-      {
-        tag: 'p',
-        label: 'Paragraph (P)'
-      },
-      {
-        tag: 'h3',
-        label: 'Heading 3 (H3)'
-      },
-      {
-        tag: 'h4',
-        label: 'Heading 4 (H4)'
-      }
-    ],
-    insert: [
-      'table',
-      'image'
-    ]
-  }
+  '@apostrophecms/rich-text': {}
 };

--- a/backend/modules/@apostrophecms/blog/index.js
+++ b/backend/modules/@apostrophecms/blog/index.js
@@ -5,37 +5,7 @@ module.exports = {
         type: 'area',
         options: {
           widgets: {
-            '@apostrophecms/rich-text': {
-              toolbar: [
-                'styles',
-                '|',
-                'bold',
-                'italic',
-                'strike',
-                'link',
-                '|',
-                'bulletList',
-                'orderedList'
-              ],
-              styles: [
-                {
-                  tag: 'p',
-                  label: 'Paragraph (P)'
-                },
-                {
-                  tag: 'h3',
-                  label: 'Heading 3 (H3)'
-                },
-                {
-                  tag: 'h4',
-                  label: 'Heading 4 (H4)'
-                }
-              ],
-              insert: [
-                'table',
-                'image'
-              ]
-            },
+            '@apostrophecms/rich-text': {},
             '@apostrophecms/image': {},
             '@apostrophecms/video': {},
             'two-column': {}

--- a/backend/modules/@apostrophecms/home-page/index.js
+++ b/backend/modules/@apostrophecms/home-page/index.js
@@ -8,37 +8,7 @@ module.exports = {
         type: 'area',
         options: {
           widgets: {
-            '@apostrophecms/rich-text': {
-              toolbar: [
-                'styles',
-                '|',
-                'bold',
-                'italic',
-                'strike',
-                'link',
-                '|',
-                'bulletList',
-                'orderedList'
-              ],
-              styles: [
-                {
-                  tag: 'p',
-                  label: 'Paragraph (P)'
-                },
-                {
-                  tag: 'h3',
-                  label: 'Heading 3 (H3)'
-                },
-                {
-                  tag: 'h4',
-                  label: 'Heading 4 (H4)'
-                }
-              ],
-              insert: [
-                'table',
-                'image'
-              ]
-            },
+            '@apostrophecms/rich-text': {},
             '@apostrophecms/image': {},
             '@apostrophecms/video': {},
             'two-column': {}

--- a/backend/modules/default-page/index.js
+++ b/backend/modules/default-page/index.js
@@ -9,37 +9,7 @@ module.exports = {
         type: 'area',
         options: {
           widgets: {
-            '@apostrophecms/rich-text': {
-              toolbar: [
-                'styles',
-                '|',
-                'bold',
-                'italic',
-                'strike',
-                'link',
-                '|',
-                'bulletList',
-                'orderedList'
-              ],
-              styles: [
-                {
-                  tag: 'p',
-                  label: 'Paragraph (P)'
-                },
-                {
-                  tag: 'h3',
-                  label: 'Heading 3 (H3)'
-                },
-                {
-                  tag: 'h4',
-                  label: 'Heading 4 (H4)'
-                }
-              ],
-              insert: [
-                'table',
-                'image'
-              ]
-            },
+            '@apostrophecms/rich-text': {},
             '@apostrophecms/image': {},
             '@apostrophecms/video': {},
             'two-column': {}


### PR DESCRIPTION
[PRO-7646](https://linear.app/apostrophecms/issue/PRO-7646/as-an-editor-i-want-multiple-headings-in-the-rich-text-toolbar-set-up)

## Summary

Remove all rich-text specific configs to use new default.
⚠️ Waiting for [this one](https://github.com/apostrophecms/apostrophe/pull/4941) to be merged and released.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
